### PR TITLE
CRONAPP-2635 Erro no console ao tentar abrir um relatório

### DIFF
--- a/dist/js/stimulsoft/stimulsoft-helper.js
+++ b/dist/js/stimulsoft/stimulsoft-helper.js
@@ -202,7 +202,12 @@ StimulsoftHelper.prototype.getParamsFromFilter = function(datasource) {
     var column = this.getColumnByName(datasource, r.field);
     var type = "String";
     if (column) {
-      type = column.type();
+      try {
+        type = column.type();
+      }
+      catch (e) {
+        type = null;
+      }
       if (!type)
         type = column._type.ssTypeName;
       if (!type)


### PR DESCRIPTION
**Problema:**
Erro no console ao tentar abrir um relatório

**Solução:**
Versões antigas do relatório, levantam exceção ao obter o tipo pela função .type() do column, caso não consiga obter, verifica da forma antiga _type.ssTypeName;