### PR TITLE
CRONAPP-3350 Atualizar a release para 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cronapp-lib-js",
-  "version": "2.7.4",
+  "version": "2.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cronapp-lib-js",
-  "version": "2.7.4",
+  "version": "2.9.0",
   "description": "Javascript library for CronApp's projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Solução:
Atualização do npm para 2.9.0 (sem publicação no npm)